### PR TITLE
A couple typos in README + using `yarn` > `npx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # Norges Bank - Hardhat Boilerplate
 
-The tests are with these configuration makes "a copy" of the external blockchain from the RPC_URL provided. These lets you play with the current state in your tests.
+The tests with this configuration makes "a copy" of the external blockchain from the RPC_URL provided. This lets you play with the current state in your tests.
 
 Create a `.env.local` file from the `.env.example`. You need these to run the tests 
-- `RPC_URL`: Url to the RPC with basic authentication
+- `RPC_URL`: _unquoted_ URL to the RPC with basic authentication
 - `NOK_ADDRESS`: address to the NOK(CBToken) contract 
 - `ME_ADDRESS`: Your address or anyone else. (user to fetch balanceOf of the address)
 - `WHALE_ADDRESS`: Address of someone you categorize as a "Whale" in the NOK contract. Used to transfer NOK to you if you want more 💰
 
-`./contracts` contains CBContract.sol which is the actual contract for NOK token.
+`./contracts` contains `CBContract.sol` which is the actual contract for NOK token.
 
 Run the test for NOK (which is deployed already) and TokenLock which we deploy automatically before tests are run
+
 ```
-npx hardhat test
+yarn test
 ```
 
 ### Impersonate accounts


### PR DESCRIPTION
I modified the README slightly when setting up my own project locally. My aim is to make the README slightly clearer, and correct the use of `npx`; This lead me down a rabbit whole of issues with `npm` vs `yarn`. I believe `yarn` is used by @aridder and thus the examples should use that too IMO.